### PR TITLE
🔒 Fix potential memory exhaustion vulnerability in socket reads

### DIFF
--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -1,5 +1,5 @@
 use pwsp::{
-    types::socket::{Request, Response},
+    types::socket::{Request, Response, MAX_MESSAGE_SIZE},
     utils::{
         commands::parse_command,
         daemon::{
@@ -109,7 +109,7 @@ async fn commands_loop(listener: UnixListener) -> Result<(), Box<dyn Error>> {
 
             let request_len = u32::from_le_bytes(len_bytes) as usize;
 
-            if request_len > 10 * 1024 * 1024 {
+            if request_len > MAX_MESSAGE_SIZE {
                 eprintln!(
                     "Failed to read message from client: request too large ({} bytes)!",
                     request_len

--- a/src/types/socket.rs
+++ b/src/types/socket.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub const MAX_MESSAGE_SIZE: usize = 128 * 1024;
+
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Request {
     pub name: String,

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -2,7 +2,7 @@ use crate::{
     types::{
         audio_player::AudioPlayer,
         config::DaemonConfig,
-        socket::{Request, Response},
+        socket::{Request, Response, MAX_MESSAGE_SIZE},
     },
     utils::pipewire::{create_link, get_device},
 };
@@ -134,6 +134,14 @@ pub async fn make_request(request: Request) -> Result<Response, Box<dyn Error + 
         return Err("Failed to read response length".into());
     }
     let response_len = u32::from_le_bytes(len_bytes) as usize;
+
+    if response_len > MAX_MESSAGE_SIZE {
+        eprintln!(
+            "Failed to read response from daemon: response too large ({} bytes)!",
+            response_len
+        );
+        return Err("Response too large".into());
+    }
 
     let mut buffer = vec![0u8; response_len];
     if stream.read_exact(&mut buffer).await.is_err() {


### PR DESCRIPTION
🎯 **What:** This PR fixes a vulnerability where the daemon and client utilities were willing to allocate excessively large vectors (up to 10MB) when reading messages from the Unix socket based entirely on an unvalidated length header.

⚠️ **Risk:** A malicious or malfunctioning local process with access to the socket could send a 4-byte payload indicating a 10MB size, forcing the application to allocate a large buffer. Repeated requests could lead to a Denial-of-Service (DoS) via memory exhaustion (OOM), crashing the daemon and disrupting audio playback functionality for the user.

🛡️ **Solution:** The upper limit for the IPC message payload size has been drastically reduced to a safer, more appropriate constant `MAX_MESSAGE_SIZE` (128 KB, defined in `src/types/socket.rs`). This limit is now strictly enforced on both the server-side (daemon requests) and client-side (daemon responses) before any memory allocation occurs, logging an explicit error to standard error if the limit is exceeded. 128 KB is more than enough for the expected hotkey/audio device payloads within this application while preventing the exhaustion of memory.

---
*PR created automatically by Jules for task [15506155087571722230](https://jules.google.com/task/15506155087571722230) started by @arabianq*