### PR TITLE
🔒 [security fix] Remove unwrap() panic in GUI input handling

### DIFF
--- a/src/gui/input.rs
+++ b/src/gui/input.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 fn chord_from_event(modifiers: &Modifiers, key: &Key) -> Option<String> {
     let key_name = key.name();
     let is_valid = (key_name.len() == 1
-        && key_name.chars().next().unwrap().is_ascii_alphanumeric())
+        && key_name.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()))
         || (key_name.starts_with('F')
             && key_name.len() > 1
             && key_name[1..].chars().all(|c| c.is_ascii_digit()));
@@ -60,7 +60,7 @@ pub fn parse_chord(chord: &str) -> Option<(Modifiers, Key)> {
 
     let key_name = parts[parts.len() - 1];
     let is_valid = (key_name.len() == 1
-        && key_name.chars().next().unwrap().is_ascii_alphanumeric())
+        && key_name.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()))
         || (key_name.starts_with('F')
             && key_name.len() > 1
             && key_name[1..].chars().all(|c| c.is_ascii_digit()));


### PR DESCRIPTION
### 🎯 What:
Fixed a potential unwrap panic in `src/gui/input.rs` by replacing direct `.unwrap()` calls on character iterators with safer `.is_some_and()` checks.

### ⚠️ Risk:
While guarded by length checks, the use of `.unwrap()` on iterators is discouraged as it can lead to application panics if the surrounding logic is modified or if unexpected edge cases occur. In a security-sensitive context, preventing panics is crucial for application stability and resilience.

### 🛡️ Solution:
- Refactored `chord_from_event` to use `.is_some_and(|c| c.is_ascii_alphanumeric())`.
- Refactored `parse_chord` to use `.is_some_and(|c| c.is_ascii_alphanumeric())`.
- Verified the fix with a standalone Rust script to ensure correct behavior for both valid and empty input.

---
*PR created automatically by Jules for task [7667264657325163460](https://jules.google.com/task/7667264657325163460) started by @arabianq*