### PR TITLE
🧪 [testing improvement] parse_command set_volume edge cases

### DIFF
--- a/src/utils/commands.rs
+++ b/src/utils/commands.rs
@@ -122,3 +122,88 @@ pub fn parse_command(request: &Request) -> Option<Box<dyn Executable + Send>> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::socket::Request;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_parse_set_volume_valid() {
+        let mut args = HashMap::new();
+        args.insert("volume".to_string(), "0.5".to_string());
+        args.insert("id".to_string(), "1".to_string());
+        let request = Request {
+            name: "set_volume".to_string(),
+            args,
+        };
+
+        let cmd = parse_command(&request);
+        assert!(cmd.is_some());
+    }
+
+    #[test]
+    fn test_parse_set_volume_missing_volume() {
+        let mut args = HashMap::new();
+        args.insert("id".to_string(), "1".to_string());
+        let request = Request {
+            name: "set_volume".to_string(),
+            args,
+        };
+
+        let cmd = parse_command(&request);
+        assert!(cmd.is_some());
+    }
+
+    #[test]
+    fn test_parse_set_volume_invalid_volume() {
+        let mut args = HashMap::new();
+        args.insert("volume".to_string(), "not-a-float".to_string());
+        let request = Request {
+            name: "set_volume".to_string(),
+            args,
+        };
+
+        let cmd = parse_command(&request);
+        assert!(cmd.is_some());
+    }
+
+    #[test]
+    fn test_parse_set_volume_missing_id() {
+        let mut args = HashMap::new();
+        args.insert("volume".to_string(), "0.5".to_string());
+        let request = Request {
+            name: "set_volume".to_string(),
+            args,
+        };
+
+        let cmd = parse_command(&request);
+        assert!(cmd.is_some());
+    }
+
+    #[test]
+    fn test_parse_set_volume_invalid_id() {
+        let mut args = HashMap::new();
+        args.insert("id".to_string(), "not-an-int".to_string());
+        args.insert("volume".to_string(), "0.5".to_string());
+        let request = Request {
+            name: "set_volume".to_string(),
+            args,
+        };
+
+        let cmd = parse_command(&request);
+        assert!(cmd.is_some());
+    }
+
+    #[test]
+    fn test_parse_set_volume_empty_args() {
+        let request = Request {
+            name: "set_volume".to_string(),
+            args: HashMap::new(),
+        };
+
+        let cmd = parse_command(&request);
+        assert!(cmd.is_some());
+    }
+}


### PR DESCRIPTION
🎯 **What:** Addressed the missing test coverage for `parse_command` function in `src/utils/commands.rs`, specifically focusing on the `set_volume` command parsing logic and its edge cases.

📊 **Coverage:**
- Valid `set_volume` request with both `volume` and `id`.
- `set_volume` request with missing `volume`.
- `set_volume` request with invalid (non-float) `volume`.
- `set_volume` request with missing `id`.
- `set_volume` request with invalid (non-integer) `id`.
- `set_volume` request with completely empty arguments.

✨ **Result:** Improved the reliability of the command parsing logic by ensuring it handles malformed or missing IPC arguments gracefully without panicking, and established a pattern for unit testing command parsing in the codebase.

---
*PR created automatically by Jules for task [10318508221166186950](https://jules.google.com/task/10318508221166186950) started by @arabianq*