### PR TITLE
ci: fix flatpak build action by matching SDK versions

### DIFF
--- a/.github/workflows/flatter.yml
+++ b/.github/workflows/flatter.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: ghcr.io/andyholmes/flatter/freedesktop:24.08
+      image: ghcr.io/andyholmes/flatter/freedesktop:25.08
       options: --privileged
 
     steps:


### PR DESCRIPTION
Updates the container image tag in `.github/workflows/flatter.yml` from `24.08` to `25.08` to match the Flatpak SDK requirements (`25.08`).

This fixes the build failure:
```
error: org.freedesktop.Sdk/x86_64/25.08 not installed
Failed to init: Unable to find sdk org.freedesktop.Sdk version 25.08
```

---
*PR created automatically by Jules for task [11537111831984463686](https://jules.google.com/task/11537111831984463686) started by @arabianq*