### PR TITLE
🧹 Refactor `draw_track_control` into independent sub-components

### DIFF
--- a/src/gui/draw.rs
+++ b/src/gui/draw.rs
@@ -445,6 +445,99 @@ impl SoundpadGui {
         });
     }
 
+    fn draw_playback_controls(ui: &mut Ui, track: &TrackInfo) -> Option<TrackAction> {
+        let mut action = None;
+
+        let play_button = Button::new(if track.paused {
+            ICON_PLAY_ARROW
+        } else {
+            ICON_PAUSE
+        })
+        .corner_radius(15.0);
+
+        if ui.add_sized([30.0, 30.0], play_button).clicked() {
+            action = Some(if track.paused {
+                TrackAction::Resume(track.id)
+            } else {
+                TrackAction::Pause(track.id)
+            });
+        }
+
+        let loop_button = Button::new(
+            RichText::new(if track.looped {
+                ICON_REPEAT_ONE
+            } else {
+                ICON_REPEAT
+            })
+            .size(18.0),
+        )
+        .frame(false);
+
+        if ui.add_sized([15.0, 30.0], loop_button).clicked() {
+            action = Some(TrackAction::ToggleLoop(track.id));
+        }
+
+        action
+    }
+
+    fn draw_position_control(
+        ui: &mut Ui,
+        ui_state: &mut pwsp::types::gui::TrackUiState,
+        track: &TrackInfo,
+        default_slider_width: f32,
+    ) {
+        let duration = track.duration.unwrap_or(1.0);
+        let position_slider = Slider::new(&mut ui_state.position_slider_value, 0.0..=duration)
+            .show_value(false)
+            .step_by(0.01);
+
+        let position_slider_width = ui.available_width()
+            - (30.0 * 3.0)
+            - default_slider_width
+            - (ui.spacing().item_spacing.x * 6.0);
+
+        ui.spacing_mut().slider_width = position_slider_width;
+        if ui.add_sized([30.0, 30.0], position_slider).drag_stopped() {
+            ui_state.position_dragged = true;
+        }
+
+        let time_label =
+            Label::new(RichText::new(format_time_pair(track.position, duration)).monospace());
+        ui.add_sized([30.0, 30.0], time_label);
+    }
+
+    fn draw_volume_control(
+        ui: &mut Ui,
+        ui_state: &mut pwsp::types::gui::TrackUiState,
+        track: &TrackInfo,
+        default_slider_width: f32,
+    ) {
+        let volume_icon = Self::get_volume_icon(track.volume);
+        let volume_label = Label::new(RichText::new(volume_icon).size(18.0));
+        ui.add_sized([30.0, 30.0], volume_label)
+            .on_hover_text(format!("Volume: {:.0}%", track.volume * 100.0));
+
+        let volume_slider = Slider::new(&mut ui_state.volume_slider_value, 0.0..=1.0)
+            .show_value(false)
+            .step_by(0.01);
+
+        ui.spacing_mut().slider_width = default_slider_width - 30.0;
+        ui.spacing_mut().item_spacing.x = 0.0;
+
+        if ui.add_sized([30.0, 30.0], volume_slider).drag_stopped() {
+            ui_state.volume_dragged = true;
+        }
+    }
+
+    fn draw_stop_control(ui: &mut Ui, track: &TrackInfo) -> Option<TrackAction> {
+        let stop_button = Button::new(ICON_CLOSE).frame(false);
+        if ui.add_sized([30.0, 30.0], stop_button).clicked() {
+            Some(TrackAction::Stop(track.id))
+        } else {
+            None
+        }
+    }
+
     fn draw_track_control(
         ui: &mut Ui,
         app_state: &mut AppState,
@@ -475,93 +568,17 @@ impl SoundpadGui {
         let mut action = None;
 
         ui.horizontal_top(|ui| {
-            // ---------- Play Button ----------
-            let play_button = Button::new(if track.paused {
-                ICON_PLAY_ARROW
-            } else {
-                ICON_PAUSE
-            })
-            .corner_radius(15.0);
-
-            let play_button_response = ui.add_sized([30.0, 30.0], play_button);
-            if play_button_response.clicked() {
-                if track.paused {
-                    action = Some(TrackAction::Resume(track.id));
-                } else {
-                    action = Some(TrackAction::Pause(track.id));
-                }
+            if let Some(act) = Self::draw_playback_controls(ui, track) {
+                action = Some(act);
             }
-            // --------------------------------
-
-            // ---------- Loop Button ----------
-            let loop_button = Button::new(
-                RichText::new(if track.looped {
-                    ICON_REPEAT_ONE
-                } else {
-                    ICON_REPEAT
-                })
-                .size(18.0),
-            )
-            .frame(false);
-
-            let loop_button_response = ui.add_sized([15.0, 30.0], loop_button);
-            if loop_button_response.clicked() {
-                action = Some(TrackAction::ToggleLoop(track.id));
-            }
-            // --------------------------------
-
-            // ---------- Position Slider ----------
-            let duration = track.duration.unwrap_or(1.0);
-            let position_slider = Slider::new(&mut ui_state.position_slider_value, 0.0..=duration)
-                .show_value(false)
-                .step_by(0.01);
 
             let default_slider_width = ui.spacing().slider_width;
-            let position_slider_width = ui.available_width()
-                - (30.0 * 3.0)
-                - default_slider_width
-                - (ui.spacing().item_spacing.x * 6.0);
-            ui.spacing_mut().slider_width = position_slider_width;
-            let position_slider_response = ui.add_sized([30.0, 30.0], position_slider);
-            if position_slider_response.drag_stopped() {
-                ui_state.position_dragged = true;
+            Self::draw_position_control(ui, ui_state, track, default_slider_width);
+            Self::draw_volume_control(ui, ui_state, track, default_slider_width);
+
+            if let Some(act) = Self::draw_stop_control(ui, track) {
+                action = Some(act);
             }
-            // --------------------------------
-
-            // ---------- Time Label ----------
-            let time_label =
-                Label::new(RichText::new(format_time_pair(track.position, duration)).monospace());
-            ui.add_sized([30.0, 30.0], time_label);
-            // --------------------------------
-
-            // ---------- Volume Icon ----------
-            let volume_icon = Self::get_volume_icon(track.volume);
-            let volume_label = Label::new(RichText::new(volume_icon).size(18.0));
-            ui.add_sized([30.0, 30.0], volume_label)
-                .on_hover_text(format!("Volume: {:.0}%", track.volume * 100.0));
-            // --------------------------------
-
-            // ---------- Volume Slider ----------
-            let volume_slider = Slider::new(&mut ui_state.volume_slider_value, 0.0..=1.0)
-                .show_value(false)
-                .step_by(0.01);
-
-            ui.spacing_mut().slider_width = default_slider_width - 30.0;
-            ui.spacing_mut().item_spacing.x = 0.0;
-
-            let volume_slider_response = ui.add_sized([30.0, 30.0], volume_slider);
-            if volume_slider_response.drag_stopped() {
-                ui_state.volume_dragged = true;
-            }
-            // --------------------------------
-
-            // ---------- Stop Button ---------
-            let stop_button = Button::new(ICON_CLOSE).frame(false);
-            let stop_button_response = ui.add_sized([30.0, 30.0], stop_button);
-            if stop_button_response.clicked() {
-                action = Some(TrackAction::Stop(track.id));
-            }
-            // --------------------------------
         });
 
         action


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `draw_track_control` function inside `src/gui/draw.rs` was overly complex, managing the rendering and logic for several distinct UI elements (playback controls, position slider, volume slider, and stop button) within a single monolithic block.

💡 **Why:** How this improves maintainability
Extracting the logic into specific helper functions (`draw_playback_controls`, `draw_position_control`, `draw_volume_control`, and `draw_stop_control`) reduces the cognitive load required to understand `draw_track_control`. It makes unit testing or modifying individual sections much easier in the future and strictly separates the UI concerns.

✅ **Verification:** How you confirmed the change is safe
- Preserved the existing sequence of UI additions to ensure `egui` layout spacing works exactly as it did before.
- Ensured state modifications correctly propagate backwards (e.g., passing mutable references for drag state variables).
- Ran formatting checks (`cargo fmt`), linters (`cargo clippy`), and test suite (`cargo test`), fixing all errors. Code review indicated correct logic.

✨ **Result:** The improvement achieved
A cleaner `draw.rs` codebase with logically separated concerns inside `draw_track_control`, achieving better code health without any change in functionality.

---
*PR created automatically by Jules for task [10180969807350640647](https://jules.google.com/task/10180969807350640647) started by @arabianq*