### PR TITLE
fix clippy lints under rust 1.95

### DIFF
--- a/src/gui/draw.rs
+++ b/src/gui/draw.rs
@@ -10,7 +10,7 @@ use pwsp::types::socket::Request;
 use pwsp::types::{audio_player::TrackInfo, gui::AppState};
 use pwsp::utils::gui::{format_time_pair, make_request_async};
 use std::{
-    path::{Path, PathBuf},
+    path::Path,
     time::Instant,
 };
 
@@ -440,7 +440,7 @@ impl SoundpadGui {
                 )
                 .default_open(true)
                 .show(ui, |ui| {
-                    if let Some(act) = Self::draw_track_control(ui, &mut self.app_state, &track) {
+                    if let Some(act) = Self::draw_track_control(ui, &mut self.app_state, track) {
                         action = Some(act);
                     }
                 });
@@ -866,11 +866,11 @@ impl SoundpadGui {
         });
     }
 
-    fn get_hotkey_badge(&self, path: &PathBuf) -> Option<String> {
+    fn get_hotkey_badge(&self, path: &Path) -> Option<String> {
         for slot in &self.app_state.hotkey_config.slots {
             if slot.action.name == "play"
                 && let Some(file_path_str) = slot.action.args.get("file_path")
-                && Path::new(file_path_str) == path.as_path()
+                && Path::new(file_path_str) == path
             {
                 if let Some(chord) = &slot.key_chord {
                     return Some(format!("[{}]", chord));

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -21,7 +21,7 @@ use pwsp::{
 use rfd::FileDialog;
 use std::{
     error::Error,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
@@ -120,7 +120,7 @@ impl SoundpadGui {
         }
     }
 
-    pub fn play_file(&mut self, path: &PathBuf, concurrent: bool) {
+    pub fn play_file(&mut self, path: &Path, concurrent: bool) {
         make_request_async(Request::play(&path.to_string_lossy(), concurrent));
     }
 

--- a/src/utils/pipewire.rs
+++ b/src/utils/pipewire.rs
@@ -229,8 +229,8 @@ pub async fn get_all_devices() -> Result<(Vec<AudioDevice>, Vec<AudioDevice>), B
                 let mut output_devices: Vec<AudioDevice> =
                     output_devices.values().cloned().collect();
 
-                input_devices.sort_by(|a, b| a.id.cmp(&b.id));
-                output_devices.sort_by(|a, b| a.id.cmp(&b.id));
+                input_devices.sort_by_key(|a| a.id);
+                output_devices.sort_by_key(|a| a.id);
 
                 return Ok((input_devices, output_devices));
             }


### PR DESCRIPTION
`cargo clippy --all-targets -- -D warnings` fails on rust 1.95 with three new lints:

- `src/utils/pipewire.rs:232,233` unnecessary_sort_by, replaced with `sort_by_key`
- `src/gui/mod.rs:123` and `src/gui/draw.rs:869` ptr_arg, switched `&PathBuf` to `&Path`
- `src/gui/draw.rs:443` needless_borrow on the iterator var, dropped the extra `&`

Tests still pass, release build still clean.