### PR TITLE
add cmake makedepend to aur source pkgbuild

### DIFF
--- a/packages/aur/standart/.SRCINFO
+++ b/packages/aur/standart/.SRCINFO
@@ -1,13 +1,14 @@
 pkgbase = pwsp
 	pkgdesc = Lets you play audio files through your microphone
 	pkgver = 1.7.5
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/arabianq/pipewire-soundpad
 	arch = any
 	license = MIT
 	makedepends = clang
 	makedepends = rust
 	makedepends = cargo
+	makedepends = cmake
 	makedepends = pipewire
 	makedepends = alsa-lib
 	source = https://github.com/arabianq/pipewire-soundpad/archive/refs/tags/v1.7.5.tar.gz

--- a/packages/aur/standart/PKGBUILD
+++ b/packages/aur/standart/PKGBUILD
@@ -2,12 +2,12 @@
 pkgsubn=pwsp
 pkgname=pwsp
 pkgver=1.7.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Lets you play audio files through your microphone"
 arch=('any')
 url="https://github.com/arabianq/pipewire-soundpad"
 license=('MIT')
-makedepends=(clang rust cargo pipewire alsa-lib)
+makedepends=(clang rust cargo cmake pipewire alsa-lib)
 source=("$url/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
The opus support in 1.7.5 pulls in `opusic-sys` which calls `cmake` from its build script. The rpm spec got `BuildRequires: cmake` in 1a37729 but the AUR source PKGBUILD was missed. Building from AUR source fails with `cmake: command not found` unless the user happens to have cmake installed already.

Added `cmake` to `makedepends` in `packages/aur/standart/PKGBUILD` and the matching .SRCINFO. Bumped `pkgrel` to 2 since this is a build-recipe change against the same v1.7.5 tag. The bin PKGBUILD is unaffected since it only installs prebuilt binaries.