### PR TITLE
Add Cargo package ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Configured Dependabot to update Cargo packages weekly.