### PR TITLE
refactor: avoid unwrap() in ensure_stream

### DIFF
--- a/src/types/audio_player.rs
+++ b/src/types/audio_player.rs
@@ -95,7 +95,9 @@ impl AudioPlayer {
             sink.log_on_drop(false);
             self.stream_handle = Some(sink);
         }
-        Ok(self.stream_handle.as_ref().unwrap())
+        self.stream_handle
+            .as_ref()
+            .ok_or_else(|| anyhow!("Failed to initialize stream_handle"))
     }
 
     fn drop_stream(&mut self) {


### PR DESCRIPTION
🎯 **What:** Replaced the `unwrap()` call on `self.stream_handle` in `ensure_stream` with safe error propagation using `ok_or_else` and the `anyhow` macro.
💡 **Why:** `unwrap()` can cause a panic if the option is `None`. By propagating the error, we improve code safety and maintainability. `anyhow` is already used in this file for `Result` types.
✅ **Verification:** Verified with `cargo test`, `cargo check` and `cargo clippy`. No functionality breaks were introduced and code complies with formatting rules.
✨ **Result:** Safe error propagation prevents potential panics when initializing the stream handle.

---
*PR created automatically by Jules for task [7566957556053432097](https://jules.google.com/task/7566957556053432097) started by @arabianq*