### PR TITLE
fix: incorrect install icon name on AUR PKGBUILDs

### DIFF
--- a/packages/aur/bin/PKGBUILD
+++ b/packages/aur/bin/PKGBUILD
@@ -25,7 +25,7 @@ package() {
   install -Dm755 "${srcdir}/pwsp-gui" "${pkgdir}/usr/bin/pwsp-gui"
 
   install -Dm644 "$_srcsrc/assets/pwsp-gui.desktop" "${pkgdir}/usr/share/applications/pwsp-gui.desktop"
-  install -Dm644 "$_srcsrc/assets/icon.png" "${pkgdir}/usr/share/icons/hicolor/256x256/apps/icon.png"
+  install -Dm644 "$_srcsrc/assets/icon.png" "${pkgdir}/usr/share/icons/hicolor/256x256/apps/pwsp.png"
   install -Dm644 "$_srcsrc/assets/pwsp-daemon.service" "${pkgdir}/usr/lib/systemd/user/pwsp-daemon.service"
   
   install -Dm644 "$_srcsrc/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"

--- a/packages/aur/standart/PKGBUILD
+++ b/packages/aur/standart/PKGBUILD
@@ -41,7 +41,7 @@ package() {
   install -Dm755 "target/release/pwsp-gui" "${pkgdir}/usr/bin/pwsp-gui"
 
   install -Dm644 "assets/pwsp-gui.desktop" "${pkgdir}/usr/share/applications/pwsp-gui.desktop"
-  install -Dm644 "assets/icon.png" "${pkgdir}/usr/share/icons/hicolor/256x256/apps/icon.png"
+  install -Dm644 "assets/icon.png" "${pkgdir}/usr/share/icons/hicolor/256x256/apps/pwsp.png"
 
   install -Dm644 "assets/pwsp-daemon.service" "${pkgdir}/usr/lib/systemd/user/pwsp-daemon.service"
 }


### PR DESCRIPTION
I'm using the pwsp-bin package and noticed the desktop icon wasn't displaying. After looking into it, I found a typo in the icon name within the PKGBUILD and have corrected it in this PR.