### PR TITLE
fix(daemon): Replace unwrap with safe Option handling in audio_player

### DIFF
--- a/src/types/audio_player.rs
+++ b/src/types/audio_player.rs
@@ -349,7 +349,11 @@ impl AudioPlayer {
 
                 let duration = source.total_duration().map(|d| d.as_secs_f32());
 
-                let mixer = self.stream_handle.as_ref().unwrap().mixer();
+                let mixer = self
+                    .stream_handle
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("stream_handle is unexpectedly missing"))?
+                    .mixer();
                 let sink = Player::connect_new(mixer);
                 sink.set_volume(self.volume); // Default volume is 1.0 * master
                 sink.append(source);


### PR DESCRIPTION
🎯 **What:** Replaced an unsafe `.unwrap()` call on an `Option` inside the `play` function of `src/types/audio_player.rs` with safe error propagation using `.ok_or_else` and the `?` operator.

⚠️ **Risk:** If `self.stream_handle` was ever `None` when this line was executed (e.g., due to a data race or edge-case failure in `ensure_stream()`), the application would panic and crash, leading to a denial of service (DoS) for the user.

🛡️ **Solution:** The fix safely unwraps the `Option` by returning an `anyhow::Error` if `stream_handle` is missing. This gracefully propagates the error up the call stack instead of panicking, maintaining system stability and adhering to the project's 'no-panic' policy.

---
*PR created automatically by Jules for task [11215144502080892913](https://jules.google.com/task/11215144502080892913) started by @arabianq*