### PR TITLE
🔒 Fix unhandled panic on missing config directory

### DIFF
--- a/pwsp-lib/src/utils/config.rs
+++ b/pwsp-lib/src/utils/config.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::PathBuf;
 
 pub fn get_config_path() -> Result<PathBuf> {
-    let config_path = dirs::config_dir().expect("Failed to obtain config dir");
+    let config_path = dirs::config_dir().context("Failed to obtain config dir")?;
     Ok(config_path.join("pwsp"))
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an unhandled panic triggered by `expect("Failed to obtain config dir")` when the configuration directory could not be resolved.
⚠️ **Risk:** The potential impact if left unfixed was a Denial of Service (DoS) resulting from an application crash if the system lacked a definable configuration directory (or if the environment variables overriding it were misconfigured).
🛡️ **Solution:** The fix replaces `.expect()` with `.context("...")?` using the `anyhow` crate to cleanly return an `Err` up the call stack, preserving the application's stability while signaling an error.

---
*PR created automatically by Jules for task [16669182224731907856](https://jules.google.com/task/16669182224731907856) started by @arabianq*