### PR TITLE
🔒 Fix arbitrary file overwrite via path traversal

### DIFF
--- a/pwsp-gui/src/main.rs
+++ b/pwsp-gui/src/main.rs
@@ -3,7 +3,10 @@ mod gui;
 use anyhow::{Context, Result};
 use pwsp_lib::utils::gui::ensure_pwsp_audio_dir;
 use rust_i18n::i18n;
-use std::{env, path::PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 i18n!("locales", fallback = "en");
 
@@ -44,7 +47,7 @@ async fn download_audio_from_url(uri: &str) -> Result<PathBuf> {
         .into_owned();
 
     let normalized_file_name = file_name.replace('\\', "/");
-    let sanitized_file_name = std::path::Path::new(&normalized_file_name)
+    let sanitized_file_name = Path::new(&normalized_file_name)
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("downloaded_audio.mp3");

--- a/pwsp-gui/src/main.rs
+++ b/pwsp-gui/src/main.rs
@@ -43,7 +43,13 @@ async fn download_audio_from_url(uri: &str) -> Result<PathBuf> {
         .unwrap_or_else(|_| file_name_encoded.into())
         .into_owned();
 
-    let save_path = ensure_pwsp_audio_dir().join(file_name);
+    let normalized_file_name = file_name.replace('\\', "/");
+    let sanitized_file_name = std::path::Path::new(&normalized_file_name)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("downloaded_audio.mp3");
+
+    let save_path = ensure_pwsp_audio_dir().join(sanitized_file_name);
 
     let response = reqwest::get(target_url)
         .await?

--- a/pwsp-gui/src/main.rs
+++ b/pwsp-gui/src/main.rs
@@ -1,11 +1,12 @@
 mod gui;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use pwsp_lib::utils::gui::ensure_pwsp_audio_dir;
 use rust_i18n::i18n;
 use std::{
     env,
     path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 i18n!("locales", fallback = "en");
@@ -34,14 +35,20 @@ async fn download_audio_from_url(uri: &str) -> Result<PathBuf> {
 
     let target_url = uri
         .strip_prefix(prefix)
-        .ok_or_else(|| anyhow::anyhow!("URI does not containt an expected prefix: {}", prefix))?;
+        .ok_or_else(|| anyhow!("URI does not containt an expected prefix: {}", prefix))?;
 
-    let file_name_encoded = target_url
-        .split('/')
-        .next_back()
-        .unwrap_or("downloaded_audio.mp3");
+    let file_name_encoded = match target_url.split('/').next_back() {
+        Some(path) => path.to_string(),
+        None => {
+            let id = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went back")
+                .as_nanos();
+            format!("downloaded_audio_{}.mp3", id)
+        }
+    };
 
-    let file_name = percent_encoding::percent_decode_str(file_name_encoded)
+    let file_name = percent_encoding::percent_decode_str(&file_name_encoded.clone())
         .decode_utf8()
         .unwrap_or_else(|_| file_name_encoded.into())
         .into_owned();


### PR DESCRIPTION
🎯 **What:** This PR fixes a path traversal vulnerability in the file saving mechanism for downloaded audio in `pwsp-gui/src/main.rs`.
⚠️ **Risk:** The previous implementation extracted the file name directly from the user-provided URL and joined it to the audio directory. An attacker could craft a malicious URL with `../` (or URL-encoded equivalent) and overwrite critical arbitrary files on the user's system (e.g., `~/.bashrc`).
🛡️ **Solution:** Implemented proper filename sanitization by normalizing backslashes to forward slashes, and extracting the terminal file name component using Rust's standard library `std::path::Path::new(...).file_name()`. If the resulting string isn't a valid standalone filename, we gracefully fall back to the generic `downloaded_audio.mp3`.

---
*PR created automatically by Jules for task [7487621085416611727](https://jules.google.com/task/7487621085416611727) started by @arabianq*