### PR TITLE
fix(lib): don't create '~' in $HOME

### DIFF
--- a/pwsp-gui/src/main.rs
+++ b/pwsp-gui/src/main.rs
@@ -59,7 +59,7 @@ async fn download_audio_from_url(uri: &str) -> Result<PathBuf> {
         .and_then(|n| n.to_str())
         .unwrap_or("downloaded_audio.mp3");
 
-    let save_path = ensure_pwsp_audio_dir().join(sanitized_file_name);
+    let save_path = ensure_pwsp_audio_dir()?.join(sanitized_file_name);
 
     let response = reqwest::get(target_url)
         .await?

--- a/pwsp-lib/src/types/config.rs
+++ b/pwsp-lib/src/types/config.rs
@@ -121,7 +121,7 @@ impl Default for GuiConfig {
             save_scale_factor: false,
             pause_on_exit: false,
 
-            dirs: vec![ensure_pwsp_audio_dir()],
+            dirs: vec![ensure_pwsp_audio_dir().unwrap()],
 
             preferred_theme: PreferredTheme::System,
             dirs_settings: HashMap::new(),

--- a/pwsp-lib/src/utils/gui.rs
+++ b/pwsp-lib/src/utils/gui.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use anyhow::{Result, anyhow};
 use std::{
+    fs,
     path::PathBuf,
     sync::{Arc, Mutex},
     time::Instant,
@@ -37,19 +38,19 @@ pub fn make_request_async(request: Request) {
     });
 }
 
-pub fn ensure_pwsp_audio_dir() -> PathBuf {
-    let audio_dir = dirs::audio_dir().unwrap_or_else(|| {
+pub fn ensure_pwsp_audio_dir() -> Result<PathBuf> {
+    let audio_dir = dirs::audio_dir().unwrap_or(
         dirs::home_dir()
             .map(|p| p.join("Music"))
-            .unwrap_or_else(|| "Music".into()) // already relative to $HOME afaik
-    });
+            .ok_or_else(|| anyhow!("Failed to get home directory. Is your system ok?"))?,
+    );
     let pwsp_audio_dir = audio_dir.join("PWSP");
 
     if !pwsp_audio_dir.exists() {
-        std::fs::create_dir_all(&pwsp_audio_dir).ok();
+        fs::create_dir_all(&pwsp_audio_dir)?;
     }
 
-    pwsp_audio_dir
+    Ok(pwsp_audio_dir)
 }
 
 pub fn format_time_pair(position: f32, duration: f32) -> String {

--- a/pwsp-lib/src/utils/gui.rs
+++ b/pwsp-lib/src/utils/gui.rs
@@ -38,7 +38,11 @@ pub fn make_request_async(request: Request) {
 }
 
 pub fn ensure_pwsp_audio_dir() -> PathBuf {
-    let audio_dir = dirs::audio_dir().unwrap_or("~/Music".into());
+    let audio_dir = dirs::audio_dir().unwrap_or_else(|| {
+        dirs::home_dir()
+            .map(|p| p.join("Music"))
+            .unwrap_or_else(|| "Music".into()) // already relative to $HOME afaik
+    });
     let pwsp_audio_dir = audio_dir.join("PWSP");
 
     if !pwsp_audio_dir.exists() {


### PR DESCRIPTION
i've noticed that pwsp was creating a dir with the literal name '~' in my home directory. i suppose that it's unintended behavior, so i patched it by using dirs::home_dir() instead.
tested manually with cargo run.